### PR TITLE
NGWMN-2151 Http error handling

### DIFF
--- a/etl/extract.py
+++ b/etl/extract.py
@@ -38,7 +38,7 @@ class Extract:
         next_chunk = self.construct_url(registry_ml_endpoint)
         results = []
 
-        with Session() as session:
+        with self.session() as session:
             while next_chunk:
                 fetches += 1
                 if fetches % self.FETCHES_PER_LOG == 0:
@@ -61,6 +61,14 @@ class Extract:
 
         logging.info(f'Finished retrieving {len(results)} monitoring locations.')
         return results
+
+    # noinspection PyMethodMayBeStatic
+    # pylint: disable=too-few-public-methods, no-member
+    def session(self):
+        """
+        Facilitates unit testing by allowing the override to return a mock
+        """
+        return Session()
 
     def fetch_record_block(self, url, session):
         attempt_count_net = 1

--- a/etl/extract.py
+++ b/etl/extract.py
@@ -10,140 +10,147 @@ from requests import Session
 from requests.exceptions import RequestException
 from requests.exceptions import HTTPError
 
-"""Number of records to fetch in at once"""
-FETCH_LIMIT = 8
-"""Number of times to retry when there is a network error"""
-FETCH_TRIES_FOR_NETWORK_ERROR = 2
-"""Number of times to retry when there is an HTTP Status code other than ok"""
-FETCH_TRIES_FOR_STATUS_CODE = 2
-"""Number of times to retry when there is the JSON fails to decode"""
-FETCH_TRIES_FOR_JSON = 2
-"""Number of times to accept a missing data for aborting the ETL"""
-FETCH_JSON_ERROR_TOLERANCE = 2
-"""Number of seconds to wait before a retry is attempted"""
-FETCH_RETRY_DELAY = 10
-"""Number of fetches per info log"""
-FETCHES_PER_LOG = 128
 
+class Extract:
+    def __init__(self):
+        """Number of records to fetch in at once"""
+        self.FETCH_LIMIT = 8
+        """Number of times to retry when there is a network error"""
+        self.FETCH_TRIES_FOR_NETWORK_ERROR = 2
+        """Number of times to retry when there is an HTTP Status code other than ok"""
+        self.FETCH_TRIES_FOR_STATUS_CODE = 2
+        """Number of times to retry when there is the JSON fails to decode"""
+        self.FETCH_TRIES_FOR_JSON = 2
+        """Number of times to accept a missing data for aborting the ETL"""
+        self.FETCH_JSON_ERROR_TOLERANCE = 2
+        """Number of seconds to wait before a retry is attempted"""
+        self.FETCH_RETRY_DELAY = 10
+        """Number of fetches per info log"""
+        self.FETCHES_PER_LOG = 128
 
-def get_monitoring_locations(registry_ml_endpoint):
-    """
-    Get the monitoring location data.
-    """
-    # initialize state of errors, URL, and results
-    json_fail_count = 0
-    fetches = 0
-    next_chunk = construct_url(registry_ml_endpoint)
-    results = []
+    def get_monitoring_locations(self, registry_ml_endpoint):
+        """
+        Get the monitoring location data.
+        """
+        # initialize state of errors, URL, and results
+        json_fail_count = 0
+        fetches = 0
+        next_chunk = self.construct_url(registry_ml_endpoint)
+        results = []
 
-    with Session() as session:
-        while next_chunk:
-            fetches += 1
-            if fetches % FETCHES_PER_LOG == 0:
-                logging.info(f'Retrieving monitoring locations: {next_chunk}')
+        with Session() as session:
+            while next_chunk:
+                fetches += 1
+                if fetches % self.FETCHES_PER_LOG == 0:
+                    logging.info(f'Retrieving monitoring locations: {next_chunk}')
+                try:
+                    payload = self.fetch_record_block(next_chunk, session)
+                    results.extend(payload.get('results'))
+                    next_chunk = payload.get('next')
+                except JSONDecodeError as json_err:
+                    json_fail_count += 1
+                    if json_fail_count > self.FETCH_JSON_ERROR_TOLERANCE:
+                        logging.error('Abort: JSON errors exceeded. Set FETCH_JSON_ERROR_TOLERANCE to fine tune.')
+                        raise JSONDecodeError('JSON errors exceeded.', json_err.doc, json_err.pos)
+                    else:
+                        logging.warning(
+                            f'JSON error occurred, {self.FETCH_JSON_ERROR_TOLERANCE-json_fail_count} before abort.')
+                except RequestException:
+                    logging.error(f'Unrecoverable error fetching data from {next_chunk}')
+                    return []
+
+        logging.info(f'Finished retrieving {len(results)} monitoring locations.')
+        return results
+
+    def fetch_record_block(self, url, session):
+        attempt_count_net = 1
+        attempt_count_status = 1
+        attempt_count_json = 1
+        attempts_remain = True
+        recent_json_error = None
+        payload = None
+
+        while attempts_remain:
+            # if this is a retry then pause for a delay to see if it recovers
+            if attempt_count_net + attempt_count_status + attempt_count_json > 3:
+                logging.warning(f'Retrying request in {self.FETCH_RETRY_DELAY} seconds')
+                sleep(self.FETCH_RETRY_DELAY)
+
             try:
-                payload = fetch_record_block(next_chunk, session)
-                results.extend(payload.get('results'))
-                next_chunk = payload.get('next')
-            except JSONDecodeError as json_err:
-                json_fail_count += 1
-                if json_fail_count > FETCH_JSON_ERROR_TOLERANCE:
-                    logging.error('Abort: JSON errors exceeded. Set FETCH_JSON_ERROR_TOLERANCE to fine tune.')
-                    raise JSONDecodeError('JSON errors exceeded.', json_err.doc, json_err.pos)
+                payload = self.try_fetch(url, session)
+                attempts_remain = False  # indicate that we are done
+            except HTTPError as se:  # trap http status error before the more general RequestException
+                attempt_count_status += 1
+                logging.warning(f'HTTP status code, {se.response.status_code}, from URL: {url}')
+            except RequestException as re:  # trap network issues
+                attempt_count_net += 1
+                if re.response is None:
+                    logging.warning(f'No response entity from URL: {url}')
                 else:
-                    logging.warning(f'JSON error occurred, {FETCH_JSON_ERROR_TOLERANCE-json_fail_count} before abort.')
-            except RequestException:
-                logging.error(f'Unrecoverable error fetching data from {next_chunk}')
-                return []
+                    logging.warning(f'Exception requesting URL: {url}')
+            except JSONDecodeError as json_err:  # trap JSON parsing errors
+                recent_json_error = json_err
+                attempt_count_json += 1
+                logging.warning(f'JSON parsing error in response from: {url}')
+                logging.warning(json_err)
+                logging.warning(json_err.doc)
 
-    logging.info(f'Finished retrieving {len(results)} monitoring locations.')
-    return results
+            # exit loop if done/success or too many tries of any type
+            attempts_remain &= attempt_count_net <= self.FETCH_TRIES_FOR_NETWORK_ERROR \
+                and attempt_count_status <= self.FETCH_TRIES_FOR_STATUS_CODE \
+                and attempt_count_json <= self.FETCH_TRIES_FOR_JSON
 
+        # allow for the caller to know how often the JSON was bad
+        if attempt_count_json > self.FETCH_TRIES_FOR_JSON:
+            doc = recent_json_error.doc if recent_json_error is not None else ''
+            pos = recent_json_error.pos if recent_json_error is not None else 0
+            raise JSONDecodeError("Exceeded JSON Tries.", doc, pos)
 
-def fetch_record_block(url, session):
-    attempt_count_net = 1
-    attempt_count_status = 1
-    attempt_count_json = 1
-    attempts_remain = True
+        if attempt_count_net > self.FETCH_TRIES_FOR_NETWORK_ERROR \
+                or attempt_count_status > self.FETCH_TRIES_FOR_STATUS_CODE:
+            logging.warning(f'Retrying failed')
+            raise RequestException()
 
-    while attempts_remain:
+        if payload is None:  # ideally we should not raise this exception
+            raise ValueError("Response was never set and this should not happen.")
+
         # if this is a retry then pause for a delay to see if it recovers
         if attempt_count_net + attempt_count_status + attempt_count_json > 3:
-            logging.warning(f'Retrying request in {FETCH_RETRY_DELAY} seconds')
-            sleep(FETCH_RETRY_DELAY)
+            logging.info(f'Retrying succeeded')
+
+        return payload
+
+    @staticmethod
+    def try_fetch(url, session):
+        response = session.get(url)
+
+        if response is None:  # trap no response
+            raise RequestException()
+
+        # status codes above 203 are reduced content status codes - that is bad
+        if response.status_code >= 204:  # trap bad status code
+            raise response.raise_for_status()
 
         try:
-            payload = try_fetch(url, session)
-            attempts_remain = False  # indicate that we are done
-        except HTTPError as se:  # trap http status error before the more general RequestException
-            attempt_count_status += 1
-            logging.warning(f'HTTP status code, {se.response.status_code}, from URL: {url}')
-        except RequestException as re:  # trap network issues
-            attempt_count_net += 1
-            if re.response is None:
-                logging.warning(f'No response entity from URL: {url}')
+            json = response.json()
+        except JSONDecodeError as json_err:
+            # put the response text on the exception
+            json_err.doc = response.text
+            raise json_err
+
+        return json
+
+    def construct_url(self, endpoint):
+        """
+        Construct the URL with a smaller limit than the 1024 default
+        """
+        url = endpoint
+
+        if 'limit' not in url:
+            if '?' not in url:
+                url += '?'
             else:
-                logging.warning(f'Exception requesting URL: {url}')
-        except JSONDecodeError as json_err:  # trap JSON parsing errors
-            recent_json_error = json_err
-            attempt_count_json += 1
-            logging.warning(f'JSON parsing error in response from: {url}')
-            logging.warning(json_err)
-            logging.warning(json_err.doc)
+                url += '&'
+            url += 'limit=' + str(self.FETCH_LIMIT)
 
-        # exit loop if done/success or too many tries of any type
-        attempts_remain &= attempt_count_net <= FETCH_TRIES_FOR_NETWORK_ERROR \
-            and attempt_count_status <= FETCH_TRIES_FOR_STATUS_CODE \
-            and attempt_count_json <= FETCH_TRIES_FOR_JSON
-
-    # allow for the caller to know how often the JSON was bad
-    if attempt_count_json > FETCH_TRIES_FOR_JSON:
-        doc = recent_json_error.doc if recent_json_error is None else ''
-        pos = recent_json_error.pos if recent_json_error is None else 0
-        raise JSONDecodeError("Exceeded JSON Tries.", doc, pos)
-
-    if attempt_count_net > FETCH_TRIES_FOR_NETWORK_ERROR or attempt_count_status > FETCH_TRIES_FOR_STATUS_CODE:
-        logging.warning(f'Retrying failed')
-        raise RequestException()
-
-    # if this is a retry then pause for a delay to see if it recovers
-    if attempt_count_net + attempt_count_status + attempt_count_json > 3:
-        logging.info(f'Retrying succeeded')
-
-    return payload
-
-
-def try_fetch(url, session):
-    respsponse = session.get(url)
-
-    if respsponse is None:  # trap no response
-        raise RequestException()
-
-    # status codes above 203 are reduced content status codes - that is bad
-    if respsponse.status_code >= 204:  # trap bad status code
-        raise respsponse.raise_for_status()
-
-    try:
-        json = respsponse.json()
-    except JSONDecodeError as json_err:
-        # put the response text on the exception
-        json_err.doc = respsponse.text
-        raise json_err
-
-    return json
-
-
-def construct_url(endpoint):
-    """
-    Construct the URL with a smaller limit than the 1024 default
-    """
-    url = endpoint
-
-    if 'limit' not in url:
-        if '?' not in url:
-            url += '?'
-        else:
-            url += '&'
-        url += 'limit=' + str(FETCH_LIMIT)
-
-    return url
+        return url

--- a/etl/extract.py
+++ b/etl/extract.py
@@ -4,22 +4,146 @@ Functions to retrieve data from the Well Registry API
 
 import logging
 
+from time import sleep
+from json.decoder import JSONDecodeError
 from requests import Session
+from requests.exceptions import RequestException
+from requests.exceptions import HTTPError
+
+"""Number of records to fetch in at once"""
+FETCH_LIMIT = 8
+"""Number of times to retry when there is a network error"""
+FETCH_TRIES_FOR_NETWORK_ERROR = 2
+"""Number of times to retry when there is an HTTP Status code other than ok"""
+FETCH_TRIES_FOR_STATUS_CODE = 2
+"""Number of times to retry when there is the JSON fails to decode"""
+FETCH_TRIES_FOR_JSON = 2
+"""Number of times to accept a missing data for aborting the ETL"""
+FETCH_JSON_ERROR_TOLERANCE = 2
+"""Number of seconds to wait before a retry is attempted"""
+FETCH_RETRY_DELAY = 10
+"""Number of fetches per info log"""
+FETCHES_PER_LOG = 128
 
 
 def get_monitoring_locations(registry_ml_endpoint):
     """
     Get the monitoring location data.
     """
-    next_chunk = registry_ml_endpoint
+    # initialize state of errors, URL, and results
+    json_fail_count = 0
+    fetches = 0
+    next_chunk = construct_url(registry_ml_endpoint)
     results = []
+
     with Session() as session:
         while next_chunk:
-            logging.info(f'Retrieving monitoring locations: {next_chunk}')
-            resp = session.get(next_chunk)
-            payload = resp.json()
-            results.extend(payload['results'])
-            next_chunk = payload['next']
+            fetches += 1
+            if fetches % FETCHES_PER_LOG == 0:
+                logging.info(f'Retrieving monitoring locations: {next_chunk}')
+            try:
+                payload = fetch_record_block(next_chunk, session)
+                results.extend(payload.get('results'))
+                next_chunk = payload.get('next')
+            except JSONDecodeError as json_err:
+                json_fail_count += 1
+                if json_fail_count > FETCH_JSON_ERROR_TOLERANCE:
+                    logging.error('Abort: JSON errors exceeded. Set FETCH_JSON_ERROR_TOLERANCE to fine tune.')
+                    raise JSONDecodeError('JSON errors exceeded.', json_err.doc, json_err.pos)
+                else:
+                    logging.warning(f'JSON error occurred, {FETCH_JSON_ERROR_TOLERANCE-json_fail_count} before abort.')
+            except RequestException:
+                logging.error(f'Unrecoverable error fetching data from {next_chunk}')
+                return []
 
     logging.info(f'Finished retrieving {len(results)} monitoring locations.')
     return results
+
+
+def fetch_record_block(url, session):
+    attempt_count_net = 1
+    attempt_count_status = 1
+    attempt_count_json = 1
+    attempts_remain = True
+
+    while attempts_remain:
+        # if this is a retry then pause for a delay to see if it recovers
+        if attempt_count_net + attempt_count_status + attempt_count_json > 3:
+            logging.warning(f'Retrying request in {FETCH_RETRY_DELAY} seconds')
+            sleep(FETCH_RETRY_DELAY)
+
+        try:
+            payload = try_fetch(url, session)
+            attempts_remain = False  # indicate that we are done
+        except HTTPError as se:  # trap http status error before the more general RequestException
+            attempt_count_status += 1
+            logging.warning(f'HTTP status code, {se.response.status_code}, from URL: {url}')
+        except RequestException as re:  # trap network issues
+            attempt_count_net += 1
+            if re.response is None:
+                logging.warning(f'No response entity from URL: {url}')
+            else:
+                logging.warning(f'Exception requesting URL: {url}')
+        except JSONDecodeError as json_err:  # trap JSON parsing errors
+            recent_json_error = json_err
+            attempt_count_json += 1
+            logging.warning(f'JSON parsing error in response from: {url}')
+            logging.warning(json_err)
+            logging.warning(json_err.doc)
+
+        # exit loop if done/success or too many tries of any type
+        attempts_remain &= attempt_count_net <= FETCH_TRIES_FOR_NETWORK_ERROR \
+            and attempt_count_status <= FETCH_TRIES_FOR_STATUS_CODE \
+            and attempt_count_json <= FETCH_TRIES_FOR_JSON
+
+    # allow for the caller to know how often the JSON was bad
+    if attempt_count_json > FETCH_TRIES_FOR_JSON:
+        doc = recent_json_error.doc if recent_json_error is None else ''
+        pos = recent_json_error.pos if recent_json_error is None else 0
+        raise JSONDecodeError("Exceeded JSON Tries.", doc, pos)
+
+    if attempt_count_net > FETCH_TRIES_FOR_NETWORK_ERROR or attempt_count_status > FETCH_TRIES_FOR_STATUS_CODE:
+        logging.warning(f'Retrying failed')
+        raise RequestException()
+
+    # if this is a retry then pause for a delay to see if it recovers
+    if attempt_count_net + attempt_count_status + attempt_count_json > 3:
+        logging.info(f'Retrying succeeded')
+
+    return payload
+
+
+def try_fetch(url, session):
+    respsponse = session.get(url)
+
+    if respsponse is None:  # trap no response
+        raise RequestException()
+
+    # status codes above 203 are reduced content status codes - that is bad
+    if respsponse.status_code >= 204:  # trap bad status code
+        raise respsponse.raise_for_status()
+
+    try:
+        json = respsponse.json()
+    except JSONDecodeError as json_err:
+        # put the response text on the exception
+        json_err.doc = respsponse.text
+        raise json_err
+
+    return json
+
+
+def construct_url(endpoint):
+    """
+    Construct the URL with a smaller limit than the 1024 default
+    """
+    url = endpoint
+
+    if 'limit' not in url:
+        if '?' not in url:
+            url += '?'
+        else:
+            url += '&'
+        url += 'limit=' + str(FETCH_LIMIT)
+
+    return url

--- a/etl/extract.py
+++ b/etl/extract.py
@@ -13,19 +13,19 @@ from requests.exceptions import HTTPError
 
 class Extract:
     def __init__(self):
-        """Number of records to fetch in at once"""
+        """Number of records to fetch in at once."""
         self.FETCH_LIMIT = 8
-        """Number of times to retry when there is a network error"""
+        """Number of times to retry when there is a network error."""
         self.FETCH_TRIES_FOR_NETWORK_ERROR = 2
-        """Number of times to retry when there is an HTTP Status code other than ok"""
+        """Number of times to retry when there is an HTTP Status code other than ok."""
         self.FETCH_TRIES_FOR_STATUS_CODE = 2
-        """Number of times to retry when there is the JSON fails to decode"""
+        """Number of times to retry when there is the JSON fails to decode."""
         self.FETCH_TRIES_FOR_JSON = 2
-        """Number of times to accept a missing data for aborting the ETL"""
+        """Number of times to accept a missing data for aborting the ETL."""
         self.FETCH_JSON_ERROR_TOLERANCE = 2
-        """Number of seconds to wait before a retry is attempted"""
+        """Number of seconds to wait before a retry is attempted."""
         self.FETCH_RETRY_DELAY = 10
-        """Number of fetches per info log"""
+        """Number of fetches per info log."""
         self.FETCHES_PER_LOG = 128
 
     def get_monitoring_locations(self, registry_ml_endpoint):
@@ -65,10 +65,11 @@ class Extract:
         return results
 
     # noinspection PyMethodMayBeStatic
-    # pylint: disable=too-few-public-methods, no-member
+    # pylint: disable=no-self-use
     def session(self):
         """
-        Facilitates unit testing by allowing the override to return a mock
+        Helper method that facilitates IoC.
+        Self-Use warning is disabled because an instance method is required to perform IoC.
         """
         return Session()
 
@@ -118,7 +119,7 @@ class Extract:
 
         if attempt_count_net > self.FETCH_TRIES_FOR_NETWORK_ERROR \
                 or attempt_count_status > self.FETCH_TRIES_FOR_STATUS_CODE:
-            logging.warning(f'Retrying failed')
+            logging.warning('Retrying failed')
             raise RequestException()
 
         if payload is None:  # ideally we should not raise this exception
@@ -126,7 +127,7 @@ class Extract:
 
         # if this is a retry then pause for a delay to see if it recovers
         if attempt_count_net + attempt_count_status + attempt_count_json > 3:
-            logging.info(f'Retrying succeeded')
+            logging.info('Retrying succeeded')
 
         return payload
 
@@ -152,7 +153,7 @@ class Extract:
 
     def construct_url(self, endpoint):
         """
-        Construct the URL with a smaller limit than the 1024 default
+        Construct the URL with a smaller limit than the 1024 default.
         """
         url = endpoint
 

--- a/etl/test/test_extract.py
+++ b/etl/test/test_extract.py
@@ -10,24 +10,36 @@ from json import JSONDecodeError
 from requests import Response, Session, HTTPError, RequestException
 import logging
 import mockito
+import copy
 
 # file under test
 from ..extract import Extract
 
 
-class TestGetMonitoringLocations(TestCase):
-    class MockResponse:
-        """
-        Mocks the requests get response
-        """
-        def __init__(self, status_code):
-            """
-            Initialize MockResponse
-            """
-            self.status_code = status_code
+class MockExtract(Extract):
+    def __init__(self, mock_session):
+        Extract.__init__(self)  # must call super constructor
+        self.mock_session = mock_session
 
-        def json(self):
-            return {'next': None, 'count': 2, 'results': ['dummyone', 'dummytwo']}
+    def session(self):
+        return self.mock_session
+
+
+class MockResponse:
+    """
+    Mocks the requests get response
+    """
+    def __init__(self, status_code):
+        """
+        Initialize MockResponse
+        """
+        self.status_code = status_code
+
+    def json(self):
+        return {'next': None, 'count': 2, 'results': ['dummyone', 'dummytwo']}
+
+
+class TestGetMonitoringLocations(TestCase):
 
     def setUp(self):
         logging.getLogger().setLevel(level=logging.INFO)
@@ -35,9 +47,13 @@ class TestGetMonitoringLocations(TestCase):
         self.extract.FETCH_RETRY_DELAY = 0
         self.fake_endpoint = 'https://fake.usgs.gov/registry/monitoring-locations/'
         self.mock_json_payload = {'good': 'json'}
+        self.mock_json_good = '{"good":"json"}'
+        self.mock_json_bad = '{"good"= json"}'
+        self.mock_payload = {'results': [{'good': 'json'}], 'next': ''}  # tests that use should set 'next'
         self.mock_session = mocki(Session)
         when(self.mock_session).__enter__().thenReturn(self.mock_session)
         when(self.mock_session).__exit__(*mockito.args)
+        print()  # to separate the log blocks per test
 
         # to be called for testing get_monitoring_locations because it uses a with-block
         # mockito.verifyStubbedInvocationsAreUsed()
@@ -48,12 +64,14 @@ class TestGetMonitoringLocations(TestCase):
 
     @mock.patch('requests.session')
     def testing_mocking_session(self, mock_session):
+        # to understand how unittest mock works -- not intuitive to me
         response1 = mock_session.get('some url')
         response2 = mock_session.get('some url')
         self.assertEqual(2, mock_session.get.call_count)
         self.assertTrue(response1 is response2)
 
     def testing_mockito_session_ab(self):
+        # to understand how mockito mocking works -- intuitive to me. I use it in Java
         url_a = 'https://fake.mon-loc.net/a'
         url_b = 'https://fake.mon-loc.net/b'
         mock_response_a = mocki({'text': 'response test text A', 'status_code': 200}, spec=Response)
@@ -72,6 +90,7 @@ class TestGetMonitoringLocations(TestCase):
         self.assertEqual(204, response3.status_code)
 
     def testing_mockito_session_thenReturn(self):
+        # to understand how mockito mocking works -- intuitive to me. I use it in Java
         mock_response_a = mocki({'text': 'response test text A', 'status_code': 200}, spec=Response)
         mock_response_b = mocki({'text': 'response test text B', 'status_code': 204}, spec=Response)
         when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a).thenReturn(mock_response_b)
@@ -83,6 +102,40 @@ class TestGetMonitoringLocations(TestCase):
 
         self.assertEqual(200, response1.status_code)
         self.assertEqual(204, response2.status_code)
+
+    def test_get_monitoring_locations_3_success(self):
+        # with mock.patch.object(Session, 'get', return_value=self.MockResponse(200)):
+        #     pass
+
+        mock_response_a = mocki({'text': self.mock_json_good, 'status_code': 200}, spec=Response)
+        mock_payload_a = copy.deepcopy(self.mock_payload)
+        mock_payload_a['next'] = self.fake_endpoint + '?limit=8&2'
+        when(mock_response_a).json().thenReturn(mock_payload_a)
+
+        mock_response_b = mocki({'text': self.mock_json_good, 'status_code': 200}, spec=Response)
+        mock_payload_b = copy.deepcopy(self.mock_payload)
+        mock_payload_b['next'] = self.fake_endpoint + '?limit=8&3'
+        when(mock_response_b).json().thenReturn(mock_payload_b)
+
+        mock_response_c = mocki({'text': self.mock_json_good, 'status_code': 200}, spec=Response)
+        mock_payload_c = copy.deepcopy(self.mock_payload)
+        mock_payload_c['next'] = None
+        when(mock_response_c).json().thenReturn(mock_payload_c)
+
+        when(self.mock_session).get(self.fake_endpoint + '?limit=8').thenReturn(mock_response_a)
+        when(self.mock_session).get(mock_payload_a['next']).thenReturn(mock_response_b)
+        when(self.mock_session).get(mock_payload_b['next']).thenReturn(mock_response_c)
+
+        extract = MockExtract(self.mock_session)
+        records = extract.get_monitoring_locations(self.fake_endpoint)
+        # the base URL is not called in this test. Extract.construct_url() adds the fetch limit in lieu of the default.
+        mockito.verify(self.mock_session, times=0).get(self.fake_endpoint)
+        # each of the batch request URLs is called once.
+        mockito.verify(self.mock_session, times=1).get(extract.construct_url(self.fake_endpoint))
+        mockito.verify(self.mock_session, times=1).get(mock_payload_a['next'])
+        mockito.verify(self.mock_session, times=1).get(mock_payload_b['next'])
+
+        self.assertEqual(3, len(records), 'there should be three mock records returned')
 
     def test_fetch_record_block_2_bad_json(self):
         # ensure that the retries works and that if the JSON is bad that it only tries TWICE

--- a/etl/test/test_extract.py
+++ b/etl/test/test_extract.py
@@ -4,15 +4,15 @@ Tests for the extract.py module
 
 # unit testing modules
 from unittest import TestCase, mock
-import mockito, logging
 from mockito import when, mock as mocki
-
 # modules referenced during testing
 from json import JSONDecodeError
 from requests import Response, Session, HTTPError, RequestException
+import logging
+import mockito
 
 # file under test
-from .. import extract
+from ..extract import Extract
 
 
 class TestGetMonitoringLocations(TestCase):
@@ -31,7 +31,8 @@ class TestGetMonitoringLocations(TestCase):
 
     def setUp(self):
         logging.getLogger().setLevel(level=logging.INFO)
-        extract.FETCH_RETRY_DELAY = 0
+        self.extract = Extract()
+        self.extract.FETCH_RETRY_DELAY = 0
         self.fake_endpoint = 'https://fake.usgs.gov/registry/monitoring-locations/'
         self.mock_json_payload = {'good': 'json'}
         self.mock_session = mocki(Session)
@@ -43,7 +44,7 @@ class TestGetMonitoringLocations(TestCase):
 
     @mock.patch.object(Session, 'get', return_value=MockResponse(200))
     def test_get_data(self, _):
-        self.assertEqual(extract.get_monitoring_locations(self.fake_endpoint), ['dummyone', 'dummytwo'])
+        self.assertEqual(self.extract.get_monitoring_locations(self.fake_endpoint), ['dummyone', 'dummytwo'])
 
     @mock.patch('requests.session')
     def testing_mocking_session(self, mock_session):
@@ -53,8 +54,8 @@ class TestGetMonitoringLocations(TestCase):
         self.assertTrue(response1 is response2)
 
     def testing_mockito_session_ab(self):
-        url_a = 'http://fake.mon-loc.net/a'
-        url_b = 'http://fake.mon-loc.net/b'
+        url_a = 'https://fake.mon-loc.net/a'
+        url_b = 'https://fake.mon-loc.net/b'
         mock_response_a = mocki({'text': 'response test text A', 'status_code': 200}, spec=Response)
         mock_response_b = mocki({'text': 'response test text B', 'status_code': 204}, spec=Response)
         when(self.mock_session).get(url_a).thenReturn(mock_response_a)
@@ -84,44 +85,46 @@ class TestGetMonitoringLocations(TestCase):
         self.assertEqual(204, response2.status_code)
 
     def test_fetch_record_block_2_bad_json(self):
-        # this test ensures that the retries works and that if the JSON is bad that it only tries TWICE
-        self.assertEqual(extract.FETCH_TRIES_FOR_JSON, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the JSON is bad that it only tries TWICE
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_JSON, 2)  # testing that it is reset between tests
 
         mock_response_a = mocki({'text': 'bad JSON twice', 'status_code': 200}, spec=Response)
         when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a)
         when(mock_response_a).json().thenRaise(JSONDecodeError('', '', 0))
 
-        self.assertRaises(JSONDecodeError, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
-        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_JSON).get(self.fake_endpoint)
+        self.assertRaises(JSONDecodeError, 
+                          lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_JSON).get(self.fake_endpoint)
 
     def test_fetch_record_block_3_bad_json(self):
-        # this test ensures that the retries works and that if the JSON is bad that it tries THREE times
-        self.assertEqual(extract.FETCH_TRIES_FOR_JSON, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the JSON is bad that it tries THREE times
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_JSON, 2)  # testing that it is reset between tests
 
         mock_response_a = mocki({'text': 'bad JSON thrice', 'status_code': 200}, spec=Response)
         when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a)
         when(mock_response_a).json().thenRaise(JSONDecodeError('', '', 0))
 
-        extract.FETCH_TRIES_FOR_JSON = 3
-        self.assertRaises(JSONDecodeError, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
-        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_JSON).get(self.fake_endpoint)
+        self.extract.FETCH_TRIES_FOR_JSON = 3
+        self.assertRaises(JSONDecodeError, 
+                          lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_JSON).get(self.fake_endpoint)
 
     def test_fetch_record_block_1_bad_json(self):
-        # this test ensures that the retries works and that if the JSON is bad the first time that it can succeed after
-        self.assertEqual(extract.FETCH_TRIES_FOR_JSON, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the JSON is bad the first time that it can succeed after
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_JSON, 2)  # testing that it is reset between tests
 
         mock_response_a = mocki({'text': 'bad JSON once', 'status_code': 200}, spec=Response)
         when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a)
         when(mock_response_a).json().thenRaise(JSONDecodeError('', '', 0)).thenReturn(self.mock_json_payload)
 
-        json_response = extract.fetch_record_block(self.fake_endpoint, self.mock_session)
+        json_response = self.extract.fetch_record_block(self.fake_endpoint, self.mock_session)
         mockito.verify(self.mock_session, times=2).get(self.fake_endpoint)
 
         self.assertEqual(self.mock_json_payload, json_response)
 
     def test_fetch_record_block_1_bad_status(self):
-        # this test ensures that the retries works and that if the STATUS CODE is bad the first time that it can succeed after
-        self.assertEqual(extract.FETCH_TRIES_FOR_STATUS_CODE, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the STATUS CODE is bad the first time that it can succeed after
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_STATUS_CODE, 2)  # testing that it is reset between tests
 
         mock_response_a = mocki({'text': 'bad JSON once', 'status_code': 300}, spec=Response)
         mock_response_b = mocki({'text': 'place holder', 'status_code': 200}, spec=Response)
@@ -131,14 +134,14 @@ class TestGetMonitoringLocations(TestCase):
         when(mock_response_a).json().thenRaise(JSONDecodeError("shouldn't call this", 'place holder', 0))
         when(mock_response_b).json().thenReturn(self.mock_json_payload)
 
-        json_response = extract.fetch_record_block(self.fake_endpoint, self.mock_session)
+        json_response = self.extract.fetch_record_block(self.fake_endpoint, self.mock_session)
         mockito.verify(self.mock_session, times=2).get(self.fake_endpoint)
 
         self.assertEqual(self.mock_json_payload, json_response)
 
     def test_fetch_record_block_2_bad_status(self):
-        # this test ensures that the retries works and that if the STATUS CODE is bad that it only tries TWICE
-        self.assertEqual(extract.FETCH_TRIES_FOR_STATUS_CODE, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the STATUS CODE is bad that it only tries TWICE
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_STATUS_CODE, 2)  # testing that it is reset between tests
 
         mock_response_a = mocki({'text': 'bad status code twice', 'status_code': 300}, spec=Response)
         when(mock_response_a).raise_for_status().thenRaise(HTTPError('http error msg', response=mock_response_a))
@@ -146,90 +149,92 @@ class TestGetMonitoringLocations(TestCase):
         when(mock_response_a).json().thenRaise(JSONDecodeError("shouldn't call this", 'place holder', 0))
 
         # the HTTPError is captured by the tries and reported as a the parent RequestException indicating non-json error
-        self.assertRaises(RequestException, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
-        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_STATUS_CODE).get(self.fake_endpoint)
+        self.assertRaises(RequestException, 
+                          lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_STATUS_CODE).get(self.fake_endpoint)
 
     def test_fetch_record_block_3_bad_status(self):
-        # this test ensures that the retries works and that if the STATUS CODE is bad that it only tries THRICE
-        self.assertEqual(extract.FETCH_TRIES_FOR_STATUS_CODE, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the STATUS CODE is bad that it only tries THRICE
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_STATUS_CODE, 2)  # testing that it is reset between tests
 
         mock_response_a = mocki({'text': 'bad status code twice', 'status_code': 300}, spec=Response)
         when(mock_response_a).raise_for_status().thenRaise(HTTPError('http error msg', response=mock_response_a))
         when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a)
         when(mock_response_a).json().thenRaise(JSONDecodeError("shouldn't call this", 'place holder', 0))
 
-        extract.FETCH_TRIES_FOR_STATUS_CODE = 3
+        self.extract.FETCH_TRIES_FOR_STATUS_CODE = 3
         # the HTTPError is captured by the tries and reported as a the parent RequestException indicating non-json error
-        self.assertRaises(RequestException, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
-        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_STATUS_CODE).get(self.fake_endpoint)
+        self.assertRaises(RequestException, 
+                          lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_STATUS_CODE).get(self.fake_endpoint)
 
     def test_fetch_record_block_1_bad_network(self):
-        # this test ensures that the retries works and that if the NETWORK is bad the first time and succeeds after
-        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the NETWORK is bad the first time and succeeds after
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
 
         mock_response_a = mocki({'text': 'place holder', 'status_code': 200}, spec=Response)
         when(self.mock_session).get(self.fake_endpoint)\
             .thenRaise(RequestException(response=mock_response_a)).thenReturn(mock_response_a)
         when(mock_response_a).json().thenReturn(self.mock_json_payload)
 
-        json_response = extract.fetch_record_block(self.fake_endpoint, self.mock_session)
+        json_response = self.extract.fetch_record_block(self.fake_endpoint, self.mock_session)
         mockito.verify(self.mock_session, times=2).get(self.fake_endpoint)
 
         self.assertEqual(self.mock_json_payload, json_response)
 
     def test_fetch_record_block_2_bad_network(self):
-        # this test ensures that the retries works and that if the NETWORK is bad that it only tries TWICE
-        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the NETWORK is bad that it only tries TWICE
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
 
         mock_response_a = mocki({'text': 'bad JSON once', 'status_code': 200}, spec=Response)
         when(self.mock_session).get(self.fake_endpoint).thenRaise(RequestException(response=mock_response_a))\
 
-        self.assertRaises(RequestException, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
-        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
+        self.assertRaises(RequestException, 
+                          lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
 
     def test_fetch_record_block_3_bad_network(self):
-        # this test ensures that the retries works and that if the NETWORK is bad that it only tries THRICE
-        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the NETWORK is bad that it only tries THRICE
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
 
         mock_response_a = mocki({'text': 'bad JSON once', 'status_code': 200}, spec=Response)
         when(self.mock_session).get(self.fake_endpoint).thenRaise(RequestException(response=mock_response_a))\
 
-        extract.FETCH_TRIES_FOR_NETWORK_ERROR = 3
-        self.assertRaises(RequestException, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
-        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
+        self.extract.FETCH_TRIES_FOR_NETWORK_ERROR = 3
+        self.assertRaises(RequestException, 
+                          lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
 
     def test_fetch_record_block_1_none_response(self):
-        # this test ensures that the retries works and that if the response is None the first time and succeeds after
-        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the response is None the first time and succeeds after
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
 
         mock_response_a = mocki({'text': 'place holder', 'status_code': 200}, spec=Response)
         when(self.mock_session).get(self.fake_endpoint).thenReturn(None).thenReturn(mock_response_a)
         when(mock_response_a).json().thenReturn(self.mock_json_payload)
 
-        json_response = extract.fetch_record_block(self.fake_endpoint, self.mock_session)
+        json_response = self.extract.fetch_record_block(self.fake_endpoint, self.mock_session)
         mockito.verify(self.mock_session, times=2).get(self.fake_endpoint)
 
         self.assertEqual(self.mock_json_payload, json_response)
 
     def test_fetch_record_block_2_none_response(self):
-        # this test ensures that the retries works and that if the response is None the first time and succeeds after
-        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the response is None the first time and succeeds after
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
 
         when(self.mock_session).get(self.fake_endpoint).thenReturn(None)
 
-        self.assertRaises(RequestException, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
-        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
+        self.assertRaises(RequestException,
+                          lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
 
     def test_fetch_record_block_3_none_response(self):
-        # this test ensures that the retries works and that if the response is None the first time and succeeds after
-        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+        # ensure that the retries works and that if the response is None the first time and succeeds after
+        self.assertEqual(self.extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
 
         when(self.mock_session).get(self.fake_endpoint).thenReturn(None)
 
-        extract.FETCH_TRIES_FOR_NETWORK_ERROR = 3
-        try:
-            extract.fetch_record_block(self.fake_endpoint, self.mock_session)
-        except RequestException:
-            mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
-            return
-        self.fail('expected RequestException')
+        self.extract.FETCH_TRIES_FOR_NETWORK_ERROR = 3
+        self.assertRaises(RequestException,
+                          lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)

--- a/etl/test/test_extract.py
+++ b/etl/test/test_extract.py
@@ -17,7 +17,13 @@ from ..extract import Extract
 
 
 class MockExtract(Extract):
+    """
+    Mocks the Extract for IoC of mocked entities.
+    """
     def __init__(self, mock_session):
+        """
+        Initialize MockExtract.
+        """
         Extract.__init__(self)  # must call super constructor
         self.mock_session = mock_session
         self.FETCH_RETRY_DELAY = 0
@@ -28,11 +34,11 @@ class MockExtract(Extract):
 
 class MockResponse:
     """
-    Mocks the requests get response
+    Mocks the requests get response.
     """
     def __init__(self, status_code):
         """
-        Initialize MockResponse
+        Initialize MockResponse.
         """
         self.status_code = status_code
 
@@ -193,7 +199,7 @@ class TestGetMonitoringLocations(TestCase):
         when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a)
         when(mock_response_a).json().thenRaise(JSONDecodeError('', '', 0))
 
-        self.assertRaises(JSONDecodeError, 
+        self.assertRaises(JSONDecodeError,
                           lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
         mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_JSON).get(self.fake_endpoint)
 
@@ -206,7 +212,7 @@ class TestGetMonitoringLocations(TestCase):
         when(mock_response_a).json().thenRaise(JSONDecodeError('', '', 0))
 
         self.extract.FETCH_TRIES_FOR_JSON = 3
-        self.assertRaises(JSONDecodeError, 
+        self.assertRaises(JSONDecodeError,
                           lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
         mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_JSON).get(self.fake_endpoint)
 
@@ -250,7 +256,7 @@ class TestGetMonitoringLocations(TestCase):
         when(mock_response_a).json().thenRaise(JSONDecodeError("shouldn't call this", 'place holder', 0))
 
         # the HTTPError is captured by the tries and reported as a the parent RequestException indicating non-json error
-        self.assertRaises(RequestException, 
+        self.assertRaises(RequestException,
                           lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
         mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_STATUS_CODE).get(self.fake_endpoint)
 
@@ -265,7 +271,7 @@ class TestGetMonitoringLocations(TestCase):
 
         self.extract.FETCH_TRIES_FOR_STATUS_CODE = 3
         # the HTTPError is captured by the tries and reported as a the parent RequestException indicating non-json error
-        self.assertRaises(RequestException, 
+        self.assertRaises(RequestException,
                           lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
         mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_STATUS_CODE).get(self.fake_endpoint)
 
@@ -290,7 +296,7 @@ class TestGetMonitoringLocations(TestCase):
         mock_response_a = mocki({'text': 'bad JSON once', 'status_code': 200}, spec=Response)
         when(self.mock_session).get(self.fake_endpoint).thenRaise(RequestException(response=mock_response_a))\
 
-        self.assertRaises(RequestException, 
+        self.assertRaises(RequestException,
                           lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
         mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
 
@@ -302,7 +308,7 @@ class TestGetMonitoringLocations(TestCase):
         when(self.mock_session).get(self.fake_endpoint).thenRaise(RequestException(response=mock_response_a))\
 
         self.extract.FETCH_TRIES_FOR_NETWORK_ERROR = 3
-        self.assertRaises(RequestException, 
+        self.assertRaises(RequestException,
                           lambda: self.extract.fetch_record_block(self.fake_endpoint, self.mock_session))
         mockito.verify(self.mock_session, times=self.extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
 

--- a/etl/test/test_extract.py
+++ b/etl/test/test_extract.py
@@ -1,11 +1,18 @@
 """
 Tests for the extract.py module
 """
+
+# unit testing modules
 from unittest import TestCase, mock
+import mockito, logging
+from mockito import when, mock as mocki
 
-from ..extract import get_monitoring_locations
+# modules referenced during testing
+from json import JSONDecodeError
+from requests import Response, Session, HTTPError, RequestException
 
-from requests import Session
+# file under test
+from .. import extract
 
 
 class TestGetMonitoringLocations(TestCase):
@@ -23,8 +30,206 @@ class TestGetMonitoringLocations(TestCase):
             return {'next': None, 'count': 2, 'results': ['dummyone', 'dummytwo']}
 
     def setUp(self):
+        logging.getLogger().setLevel(level=logging.INFO)
+        extract.FETCH_RETRY_DELAY = 0
         self.fake_endpoint = 'https://fake.usgs.gov/registry/monitoring-locations/'
+        self.mock_json_payload = {'good': 'json'}
+        self.mock_session = mocki(Session)
+        when(self.mock_session).__enter__().thenReturn(self.mock_session)
+        when(self.mock_session).__exit__(*mockito.args)
+
+        # to be called for testing get_monitoring_locations because it uses a with-block
+        # mockito.verifyStubbedInvocationsAreUsed()
 
     @mock.patch.object(Session, 'get', return_value=MockResponse(200))
     def test_get_data(self, _):
-        self.assertEqual(get_monitoring_locations(self.fake_endpoint), ['dummyone', 'dummytwo'])
+        self.assertEqual(extract.get_monitoring_locations(self.fake_endpoint), ['dummyone', 'dummytwo'])
+
+    @mock.patch('requests.session')
+    def testing_mocking_session(self, mock_session):
+        response1 = mock_session.get('some url')
+        response2 = mock_session.get('some url')
+        self.assertEqual(2, mock_session.get.call_count)
+        self.assertTrue(response1 is response2)
+
+    def testing_mockito_session_ab(self):
+        url_a = 'http://fake.mon-loc.net/a'
+        url_b = 'http://fake.mon-loc.net/b'
+        mock_response_a = mocki({'text': 'response test text A', 'status_code': 200}, spec=Response)
+        mock_response_b = mocki({'text': 'response test text B', 'status_code': 204}, spec=Response)
+        when(self.mock_session).get(url_a).thenReturn(mock_response_a)
+        when(self.mock_session).get(url_b).thenReturn(mock_response_b)
+
+        response1 = self.mock_session.get(url_a)
+        response2 = self.mock_session.get(url_a)
+        response3 = self.mock_session.get(url_b)
+
+        self.assertTrue(response1 is response2)
+        self.assertFalse(response1 is response3)
+
+        self.assertEqual(200, response1.status_code)
+        self.assertEqual(204, response3.status_code)
+
+    def testing_mockito_session_thenReturn(self):
+        mock_response_a = mocki({'text': 'response test text A', 'status_code': 200}, spec=Response)
+        mock_response_b = mocki({'text': 'response test text B', 'status_code': 204}, spec=Response)
+        when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a).thenReturn(mock_response_b)
+
+        response1 = self.mock_session.get(self.fake_endpoint)
+        response2 = self.mock_session.get(self.fake_endpoint)
+
+        self.assertFalse(response1 is response2)
+
+        self.assertEqual(200, response1.status_code)
+        self.assertEqual(204, response2.status_code)
+
+    def test_fetch_record_block_2_bad_json(self):
+        # this test ensures that the retries works and that if the JSON is bad that it only tries TWICE
+        self.assertEqual(extract.FETCH_TRIES_FOR_JSON, 2)  # testing that it is reset between tests
+
+        mock_response_a = mocki({'text': 'bad JSON twice', 'status_code': 200}, spec=Response)
+        when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a)
+        when(mock_response_a).json().thenRaise(JSONDecodeError('', '', 0))
+
+        self.assertRaises(JSONDecodeError, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_JSON).get(self.fake_endpoint)
+
+    def test_fetch_record_block_3_bad_json(self):
+        # this test ensures that the retries works and that if the JSON is bad that it tries THREE times
+        self.assertEqual(extract.FETCH_TRIES_FOR_JSON, 2)  # testing that it is reset between tests
+
+        mock_response_a = mocki({'text': 'bad JSON thrice', 'status_code': 200}, spec=Response)
+        when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a)
+        when(mock_response_a).json().thenRaise(JSONDecodeError('', '', 0))
+
+        extract.FETCH_TRIES_FOR_JSON = 3
+        self.assertRaises(JSONDecodeError, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_JSON).get(self.fake_endpoint)
+
+    def test_fetch_record_block_1_bad_json(self):
+        # this test ensures that the retries works and that if the JSON is bad the first time that it can succeed after
+        self.assertEqual(extract.FETCH_TRIES_FOR_JSON, 2)  # testing that it is reset between tests
+
+        mock_response_a = mocki({'text': 'bad JSON once', 'status_code': 200}, spec=Response)
+        when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a)
+        when(mock_response_a).json().thenRaise(JSONDecodeError('', '', 0)).thenReturn(self.mock_json_payload)
+
+        json_response = extract.fetch_record_block(self.fake_endpoint, self.mock_session)
+        mockito.verify(self.mock_session, times=2).get(self.fake_endpoint)
+
+        self.assertEqual(self.mock_json_payload, json_response)
+
+    def test_fetch_record_block_1_bad_status(self):
+        # this test ensures that the retries works and that if the STATUS CODE is bad the first time that it can succeed after
+        self.assertEqual(extract.FETCH_TRIES_FOR_STATUS_CODE, 2)  # testing that it is reset between tests
+
+        mock_response_a = mocki({'text': 'bad JSON once', 'status_code': 300}, spec=Response)
+        mock_response_b = mocki({'text': 'place holder', 'status_code': 200}, spec=Response)
+        when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a).thenReturn(mock_response_b)
+        when(mock_response_a).raise_for_status().thenRaise(HTTPError('http error msg', response=mock_response_a))
+        when(mock_response_b).raise_for_status().thenRaise(HTTPError("shouldn't call this", response=mock_response_b))
+        when(mock_response_a).json().thenRaise(JSONDecodeError("shouldn't call this", 'place holder', 0))
+        when(mock_response_b).json().thenReturn(self.mock_json_payload)
+
+        json_response = extract.fetch_record_block(self.fake_endpoint, self.mock_session)
+        mockito.verify(self.mock_session, times=2).get(self.fake_endpoint)
+
+        self.assertEqual(self.mock_json_payload, json_response)
+
+    def test_fetch_record_block_2_bad_status(self):
+        # this test ensures that the retries works and that if the STATUS CODE is bad that it only tries TWICE
+        self.assertEqual(extract.FETCH_TRIES_FOR_STATUS_CODE, 2)  # testing that it is reset between tests
+
+        mock_response_a = mocki({'text': 'bad status code twice', 'status_code': 300}, spec=Response)
+        when(mock_response_a).raise_for_status().thenRaise(HTTPError('http error msg', response=mock_response_a))
+        when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a)
+        when(mock_response_a).json().thenRaise(JSONDecodeError("shouldn't call this", 'place holder', 0))
+
+        # the HTTPError is captured by the tries and reported as a the parent RequestException indicating non-json error
+        self.assertRaises(RequestException, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_STATUS_CODE).get(self.fake_endpoint)
+
+    def test_fetch_record_block_3_bad_status(self):
+        # this test ensures that the retries works and that if the STATUS CODE is bad that it only tries THRICE
+        self.assertEqual(extract.FETCH_TRIES_FOR_STATUS_CODE, 2)  # testing that it is reset between tests
+
+        mock_response_a = mocki({'text': 'bad status code twice', 'status_code': 300}, spec=Response)
+        when(mock_response_a).raise_for_status().thenRaise(HTTPError('http error msg', response=mock_response_a))
+        when(self.mock_session).get(self.fake_endpoint).thenReturn(mock_response_a)
+        when(mock_response_a).json().thenRaise(JSONDecodeError("shouldn't call this", 'place holder', 0))
+
+        extract.FETCH_TRIES_FOR_STATUS_CODE = 3
+        # the HTTPError is captured by the tries and reported as a the parent RequestException indicating non-json error
+        self.assertRaises(RequestException, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_STATUS_CODE).get(self.fake_endpoint)
+
+    def test_fetch_record_block_1_bad_network(self):
+        # this test ensures that the retries works and that if the NETWORK is bad the first time and succeeds after
+        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+
+        mock_response_a = mocki({'text': 'place holder', 'status_code': 200}, spec=Response)
+        when(self.mock_session).get(self.fake_endpoint)\
+            .thenRaise(RequestException(response=mock_response_a)).thenReturn(mock_response_a)
+        when(mock_response_a).json().thenReturn(self.mock_json_payload)
+
+        json_response = extract.fetch_record_block(self.fake_endpoint, self.mock_session)
+        mockito.verify(self.mock_session, times=2).get(self.fake_endpoint)
+
+        self.assertEqual(self.mock_json_payload, json_response)
+
+    def test_fetch_record_block_2_bad_network(self):
+        # this test ensures that the retries works and that if the NETWORK is bad that it only tries TWICE
+        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+
+        mock_response_a = mocki({'text': 'bad JSON once', 'status_code': 200}, spec=Response)
+        when(self.mock_session).get(self.fake_endpoint).thenRaise(RequestException(response=mock_response_a))\
+
+        self.assertRaises(RequestException, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
+
+    def test_fetch_record_block_3_bad_network(self):
+        # this test ensures that the retries works and that if the NETWORK is bad that it only tries THRICE
+        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+
+        mock_response_a = mocki({'text': 'bad JSON once', 'status_code': 200}, spec=Response)
+        when(self.mock_session).get(self.fake_endpoint).thenRaise(RequestException(response=mock_response_a))\
+
+        extract.FETCH_TRIES_FOR_NETWORK_ERROR = 3
+        self.assertRaises(RequestException, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
+
+    def test_fetch_record_block_1_none_response(self):
+        # this test ensures that the retries works and that if the response is None the first time and succeeds after
+        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+
+        mock_response_a = mocki({'text': 'place holder', 'status_code': 200}, spec=Response)
+        when(self.mock_session).get(self.fake_endpoint).thenReturn(None).thenReturn(mock_response_a)
+        when(mock_response_a).json().thenReturn(self.mock_json_payload)
+
+        json_response = extract.fetch_record_block(self.fake_endpoint, self.mock_session)
+        mockito.verify(self.mock_session, times=2).get(self.fake_endpoint)
+
+        self.assertEqual(self.mock_json_payload, json_response)
+
+    def test_fetch_record_block_2_none_response(self):
+        # this test ensures that the retries works and that if the response is None the first time and succeeds after
+        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+
+        when(self.mock_session).get(self.fake_endpoint).thenReturn(None)
+
+        self.assertRaises(RequestException, lambda: extract.fetch_record_block(self.fake_endpoint, self.mock_session))
+        mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
+
+    def test_fetch_record_block_3_none_response(self):
+        # this test ensures that the retries works and that if the response is None the first time and succeeds after
+        self.assertEqual(extract.FETCH_TRIES_FOR_NETWORK_ERROR, 2)  # testing that it is reset between tests
+
+        when(self.mock_session).get(self.fake_endpoint).thenReturn(None)
+
+        extract.FETCH_TRIES_FOR_NETWORK_ERROR = 3
+        try:
+            extract.fetch_record_block(self.fake_endpoint, self.mock_session)
+        except RequestException:
+            mockito.verify(self.mock_session, times=extract.FETCH_TRIES_FOR_NETWORK_ERROR).get(self.fake_endpoint)
+            return
+        self.fail('expected RequestException')

--- a/execute.py
+++ b/execute.py
@@ -10,7 +10,7 @@ import warnings
 import cx_Oracle
 import psycopg2
 
-from etl.extract import get_monitoring_locations
+from etl.extract import Extract
 from etl.transform import transform_mon_loc_data, date_format
 from etl.load import load_monitoring_location, load_monitoring_location_pg, \
     refresh_well_registry_mv, refresh_well_registry_pg, make_oracle, make_postgres
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     if database_host is None and pg_host is None:
         raise AssertionError('One or both DATABASE_HOST and/or PG_HOST environment variables must be specified.')
 
-    mon_locs = get_monitoring_locations(registry_endpoint)
+    mon_locs = Extract().get_monitoring_locations(registry_endpoint)
     failed_locations = []
     count = 0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+pip==21.3.1
 requests==2.24.0
 cx-Oracle==8.0.1
 psycopg2-binary==2.9.1
+mockito==1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pip==21.3.1
 requests==2.24.0
 cx-Oracle==8.0.1
 psycopg2-binary==2.9.1


### PR DESCRIPTION
Added parameterized error handling counts
we can control the number of failures tolerated for specific error groups
we can also control the number of records fetched per block rather than the default from the service
added tests for the new handling

more notes in Jira